### PR TITLE
Fix incorrect settings causing failing heroku builds

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
 release: python manage.py migrate
-web: gunicorn authors.wsgi.py --log-file -
+web: gunicorn authors.wsgi --log-file -

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -21,7 +21,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = '7pgozr2jn7zs_o%i8id6=rddie!*0f0qy3$oy$(8231i^4*@u3'
 
-ALLOWED_HOSTS = []
+# locations this application can be hosted
+ALLOWED_HOSTS = [".herokuapp.com", "127.0.0.1", "localhost"]
 
 # Application definition
 
@@ -108,6 +109,8 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.10/howto/static-files/
 
 STATIC_URL = '/static/'
+
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
 
 CORS_ORIGIN_WHITELIST = (
     '0.0.0.0:4000',


### PR DESCRIPTION
#### What does this PR do?
- rename wsgi.py reference to authors.wsgi from authors.wsgi.py in heroku `Procfile`
- add the `STATIC_ROOT` path to settings
- add herokuapp to allowed hosts
#### Description of Task to be completed?
- The Procfile incorrectly referenced the `wsgi.py` as a file. It should be referenced as a module.
- The `collectstatic` command requires a destination for collected static files
- The base settings did not contain `herokuapp` as an allowed host, hence failing builds
#### How should this be manually tested?
- Visit this PR's [app](https://ah-backend-summer-stagin-pr-11.herokuapp.com/).
