### PR TITLE
fix: Modify slug create and articles views

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -34,9 +34,15 @@ class Article(models.Model):
 
 
 def article_pre_save_receiver(sender, instance, *args, **kwargs):
+    """
+    article_pre_save_reciever generates a unique slug for an article
+    create_slug function cretes are slug based on the article title
+    unique_random_string function generates a random string
+    """
+    slug = utils.create_slug(instance)
+    random_string = utils.unique_random_string()
     if not instance.slug:
-        instance.slug = f'{utils.create_slug(instance)}-\
-            {utils.unique_random_string()}'
+        instance.slug = f'{slug}-{random_string}'
 
 
 pre_save.connect(article_pre_save_receiver, sender=Article)

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -26,7 +26,8 @@ class ArticlesApiView (generics.ListCreateAPIView):
     renderer_classes = (ArticleJSONRenderer,)
 
     def post(self, request):
-        data = request.data.get('articles')
+        data = request.data.get(
+            'articles') if 'articles' in request.data else request.data
         serializer = self.serializer_class(
             data=data
         )
@@ -64,9 +65,9 @@ class ArticleDetailApiView (generics.GenericAPIView):
         article = self.get_object(slug)
         if article:
             self.check_object_permissions(request, article)
-            serializer_data = self.serializer_class(article,
-                                                    request.data.get(
-                                                        'articles'),
+            data = request.data.get(
+                'articles')if 'articles' in request.data else request.data
+            serializer_data = self.serializer_class(article, data,
                                                     partial=True)
             serializer_data.is_valid(raise_exception=True)
             serializer_data.save()


### PR DESCRIPTION
### What does this PR do?
- this fix fixes the bug where a slug was created with spaces which was
due to refactoring of code
- the swagger couldn't capture articles renderer class so in the views
request data to be captured can either contain articles or just request
data