### PR TITLE
#163383193 Users can see the time it takes to read an article

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -2,6 +2,7 @@ from rest_framework import serializers
 
 from . import models
 from ..profiles import serializers as ProfileSerializers
+from .utils.utils import get_article_read_time
 
 
 class ArticleSerializer (serializers.ModelSerializer):
@@ -14,6 +15,7 @@ class ArticleSerializer (serializers.ModelSerializer):
     author = ProfileSerializers.ProfileSerializer(read_only=True)
     favorited = serializers.SerializerMethodField()
     average_ratings = serializers.IntegerField(required=False)
+    read_time = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Article
@@ -32,7 +34,8 @@ class ArticleSerializer (serializers.ModelSerializer):
             "favoritesCount",
             "favorited",
             "average_ratings",
-            "tag_list"
+            "tag_list",
+            "read_time",
         )
         read_only_fields = (
             'author',
@@ -40,7 +43,7 @@ class ArticleSerializer (serializers.ModelSerializer):
             'created_at',
             'updated_at'
             'like_count',
-            'dislike_count'
+            'dislike_count',
         )
 
     def get_favorited(self, obj):
@@ -57,6 +60,9 @@ class ArticleSerializer (serializers.ModelSerializer):
             "author": {"read_only": True},
             "slug": {"read_only": True}
         }
+
+    def get_read_time(self, obj):
+        return get_article_read_time(obj.body)
 
 
 class ArticleRatingSerializer(serializers.ModelSerializer):

--- a/authors/apps/articles/tests/test_article_readtime.py
+++ b/authors/apps/articles/tests/test_article_readtime.py
@@ -1,0 +1,20 @@
+from rest_framework import status
+from authors.apps.articles.tests import base_class
+from ..utils.utils import get_article_read_time
+from .test_data import test_article_data
+
+
+class TestArticleReadTime(base_class.BaseTest):
+    """Class tests calculation of read time of an article"""
+
+    def test_calculate_readtime(self):
+        read_time = get_article_read_time(
+            test_article_data.one_min_read_text
+        )
+        self.assertIn("1 min read", read_time)
+
+    def test_calculate_readtime_empty_body(self):
+        read_time = get_article_read_time(
+            test_article_data.zero_min_read_text
+        )
+        self.assertIn("0 min read", read_time)

--- a/authors/apps/articles/tests/test_data/test_article_data.py
+++ b/authors/apps/articles/tests/test_data/test_article_data.py
@@ -23,3 +23,9 @@ valid_article_data_with_tags = {
     }
 }
 un_existing_slug = 'allInvalidHomie-jk23ll'
+
+one_min_read_text = "Hey there, how are you doing? \
+        Just wanted to let you know that Summer is almost here\
+        you should plan on getting your vacation in order. Thanks."
+
+zero_min_read_text = ""

--- a/authors/apps/articles/utils/utils.py
+++ b/authors/apps/articles/utils/utils.py
@@ -1,5 +1,6 @@
 import random
 import string
+import readtime
 
 from django.utils.text import slugify
 from django.db.models import Avg
@@ -22,3 +23,26 @@ def get_average_rate(**kwargs):
         return 0
     else:
         return int(average_ratings)
+
+
+def get_article_read_time(body):
+    """
+    Calculates the time some article takes the average human to read,
+    based on Medium’s read time formula.
+
+    Based on research, people are able to read English at 200 WPM
+    on paper, and 180 WPM on a monitor.
+    Read time is based on the average reading speed of an adult
+    (roughly 275 WPM). We take the total word count of a post
+    and translate it into minutes. Then, we add 12 seconds
+    for each inline image.
+
+    Parameters: Body of the article
+    Returns: average read time of an article
+
+    """
+    if body:
+        result = readtime.of_text(body)
+        return str(result)
+    else:
+        return "0 min read"

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,10 @@ six==1.12.0
 uritemplate==3.0.0
 urllib3==1.24.1
 whitenoise==4.1.2
+beautifulsoup4==4.7.1
+cssselect==1.0.3
+lxml==4.3.1
+markdown2==2.3.7
+pyquery==1.4.0
+readtime==1.0.6
+soupsieve==1.7.3


### PR DESCRIPTION
#### What does this PR do?

As a user, I should be able to see the time it will take me to read an article

#### Description of Task to be completed?

- write tests to calculate read time of an article
- add function tp calculate read time of an article in utils
- add read time to article serialiser

#### How should this be manually tested?

* Fetch and checkout this branch `ft-article-readtime-163383193`
* Create a virtual environment using `python3 -m virtualenv venv`  and activate it using `source venv\bin\activate`
* Install requirements using `pip install -r requirements.txt`
* Start the app `python manage.py runserver`
* Use postman to sign up as a user, log in, create articles and then get articles as a user

#### Any background context you want to provide?

Based on research, people are able to read English at 200 WPM on paper, and 180 WPM on a monitor.
Read time is based on the average reading speed of an adult (roughly 275 WPM). We take the total word count of an article and translate it into minutes. Then, we add 12 seconds 
for each inline image. This calculation is based on medium's read time calculation

#### What are the relevant pivotal tracker stories?

[#163383193](https://www.pivotaltracker.com/story/show/163383193)