### PR TITLE
#163383191: Articles pagination support

### DIFF
--- a/authors/apps/articles/paginators.py
+++ b/authors/apps/articles/paginators.py
@@ -1,0 +1,10 @@
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class ArticleLimitOffsetPagination(LimitOffsetPagination):
+    """ Class that will set article endpoint to only
+    only 10 articles per page
+    """
+
+    default_limit = 10
+    offset_query_param = "page"

--- a/authors/apps/articles/tests/integration/test_articles_pagination.py
+++ b/authors/apps/articles/tests/integration/test_articles_pagination.py
@@ -1,0 +1,23 @@
+from django.urls import reverse
+
+from rest_framework import status
+
+from authors.apps.articles.tests import base_class
+from ..test_data import test_article_data
+from authors.apps.articles.models import Article
+
+
+class TestArticleView(base_class.BaseTest):
+    """
+    This Test class tests the api endpoint of get all articles
+    """
+
+    def test_paginate_list_articles(self):
+        """
+        This test method tests whether the endpoint returns paginated articles
+        """
+        self.create_article_and_authenticate_test_user()
+        response = self.client.get(self.articles_url)
+        self.assertIn('count', response.data)
+        self.assertIn('results', response.data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/apps/articles/tests/test_article_api_endpoints.py
+++ b/authors/apps/articles/tests/test_article_api_endpoints.py
@@ -48,7 +48,7 @@ class TestArticleView(base_class.BaseTest):
         try getting articles when the db (Database) is empty
         """
         response = self.client.get(self.articles_url)
-        self.assertEqual([], response.data)
+        self.assertEqual([], response.data['results'])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_retrieve_all_articles_if_the_db_is_not_empty(self):
@@ -58,8 +58,8 @@ class TestArticleView(base_class.BaseTest):
         """
         self.create_article_and_authenticate_test_user()
         response = self.client.get(self.articles_url)
-        self.assertIn('title', response.data[0])
-        self.assertIn('slug', response.data[0])
+        self.assertIn('title', response.data['results'][0])
+        self.assertIn('slug', response.data['results'][0])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_retrieve_single_article(self):
@@ -96,10 +96,10 @@ class TestArticleView(base_class.BaseTest):
         """
         self.create_article_and_authenticate_test_user()
         article = Article.objects.all().first()
-        response = self.client.patch(self.article_url(article.slug),
-                                     data=test_article_data.
-                                     update_article_data,
-                                     format='json')
+        response = self.client.patch(
+            self.article_url(article.slug),
+            data=test_article_data.update_article_data,
+            format='json')
         self.assertIn('title', response.data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -111,11 +111,11 @@ class TestArticleView(base_class.BaseTest):
         self.create_article_and_authenticate_test_user()
         self.create_article_and_authenticate_test_user_2()
         article = Article.objects.all().first()
-        response = self.client.patch(reverse('articles:article-details',
-                                             kwargs={'slug': article.slug}),
-                                     data=test_article_data.
-                                     update_article_data,
-                                     format='json')
+        response = self.client.patch(
+            reverse('articles:article-details',
+                    kwargs={'slug': article.slug}),
+            data=test_article_data.update_article_data,
+            format='json')
         expected_dict_reponse = {
             'detail': 'This article does not belong to you. Access denied'}
         self.assertDictEqual(expected_dict_reponse, response.data)
@@ -128,11 +128,11 @@ class TestArticleView(base_class.BaseTest):
         """
         self.create_article_and_authenticate_test_user()
         article = Article.objects.all().first()
-        response = self.client.patch(reverse(
-            'articles:article-details',
-            kwargs={'slug':
-                    test_article_data.
-                    un_existing_slug}),
+        response = self.client.patch(
+            reverse('articles:article-details',
+                    kwargs={'slug':
+                            test_article_data.
+                            un_existing_slug}),
             data=test_article_data.update_article_data,
             format='json')
         expected_dict = {

--- a/authors/apps/articles/tests/test_rate_article.py
+++ b/authors/apps/articles/tests/test_rate_article.py
@@ -102,4 +102,4 @@ class TestRatingModel(base_class.BaseTest):
                                    format='json')
         self.assertEqual(response.status_code,
                          status.HTTP_200_OK)
-        self.assertEqual(response.data[0]['average_ratings'], 2)
+        self.assertEqual(response.data['results'][0]['average_ratings'], 2)

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -13,6 +13,7 @@ from .utils.model_helpers import *
 from ..profiles import models as profile_model
 
 from .models import Rating, Article
+from .paginators import ArticleLimitOffsetPagination
 
 
 class ArticlesApiView (generics.ListCreateAPIView):
@@ -23,6 +24,7 @@ class ArticlesApiView (generics.ListCreateAPIView):
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
     serializer_class = serializers.ArticleSerializer
     renderer_classes = (ArticleJSONRenderer,)
+    pagination_class = ArticleLimitOffsetPagination
 
     def post(self, request):
         data = request.data

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -341,6 +341,6 @@ OK to send new password information"
         serializer.is_valid(raise_exception=True)
         new_password = data.get("new_password")
         PasswordResetManager(request).update_password(email, new_password)
-        return Response(
-            {"message": "Your password has been reset"},
-            status=status.HTTP_200_OK)
+        return Response({
+            "message": "Your password has been reset"
+        }, status=status.HTTP_200_OK)

--- a/authors/apps/core/password_reset_manager.py
+++ b/authors/apps/core/password_reset_manager.py
@@ -46,8 +46,8 @@ class PasswordResetManager:
         )
         self.context = {
             'username': user.username,
-            'reset_link': self.password_reset_url + self.encoded_token.decode(
-                'utf-8') + '/'
+            'reset_link': self.password_reset_url +
+            self.encoded_token.decode('utf-8') + '/'
         }
         self.email_body = render_to_string(
             'password_reset_email.txt', self.context)


### PR DESCRIPTION
**What does this PR do?**
-  This PR ensures that all articles from the articles view page are paginated.

**Description of Task to be completed?**
- The endpoint should be able to return a specific number of articles per page
- The user should be able to move to the next page to view more articles

**How should this be manually tested?**
- Visit this [PR's](https://ah-backend-summer-stagin-pr-36.herokuapp.com) app with Postman
- Create articles
- Fetch the articles that you would like to view
- Default limit per page is  set to **10**
- `http://localhost:8000/api/v1/articles/?limit=<no_of_articles>&page=<page_no>` will allow you to decide how many articles to view on a single page and which page to view.

**Link to relevant pivotal tracker story**
[#163383191](https://www.pivotaltracker.com/story/show/163383191)