### PR TITLE
fix: Profile Return following

### DIFF
--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -3,9 +3,24 @@ from .models import Profile
 
 
 class ProfileSerializer(serializers.ModelSerializer):
+    following = serializers.SerializerMethodField()
+
     class Meta:
         model = Profile
-        fields = ("username", "first_name", "last_name", "bio", "image", )
+        fields = ("username", "first_name", "last_name", "bio", "image",
+                  "following",)
+
+    def get_following(self, instance):
+        """
+        Method to check whether logged in user is following returned
+        profile
+        """
+        request = self.context.get('request', None)
+        if request is None:
+            return False
+        follower = request.user.profile
+        followee = instance
+        return follower.is_following(followee)
 
     def validate(self, data):
         """

--- a/authors/apps/profiles/tests/test_user_follow.py
+++ b/authors/apps/profiles/tests/test_user_follow.py
@@ -163,7 +163,7 @@ class TestFollowProfile(APITestCase):
             HTTP_AUTHORIZATION=f'Bearer {self.token1}',)
         self.assertEqual(response.data['message'],
                          'You are not following anyone.')
-        self.assertEqual(response.data['status'], 400)
+        self.assertEqual(response.data['status'], 204)
 
     def test_user_can_view_all_users_who_follow_them(self):
         """ Test that a user can view all users that follow them.
@@ -189,4 +189,4 @@ class TestFollowProfile(APITestCase):
             HTTP_AUTHORIZATION=f'Bearer {self.token2}',)
         self.assertEqual(response.data['message'],
                          'You have no followers.')
-        self.assertEqual(response.data['status'], 400)
+        self.assertEqual(response.data['status'], 204)

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -22,7 +22,9 @@ class ProfileRetrieveUpdateView(generics.GenericAPIView):
     def get(self, request, username):
         profile = self.get_object(username)
         if profile:
-            serializer = self.serializer_class(profile)
+            serializer = self.serializer_class(profile, context={
+                'request': request
+            })
             response_data = {"profile": serializer.data}
             return Response(response_data, status=status.HTTP_200_OK)
         return Response({
@@ -142,8 +144,8 @@ class ProfileFollowingAPIView(generics.GenericAPIView):
         if following is None or following == []:
             msg = {
                 'message': 'You are not following anyone.',
-                'status': status.HTTP_400_BAD_REQUEST}
-            return Response(data=msg, status=status.HTTP_400_BAD_REQUEST)
+                'status': status.HTTP_204_NO_CONTENT}
+            return Response(data=msg, status=status.HTTP_204_NO_CONTENT)
         msg = {
             'following': following,
             'status': status.HTTP_200_OK}
@@ -167,8 +169,8 @@ class ProfileFollowersAPIView(generics.GenericAPIView):
         if followers is None or followers == []:
             msg = {
                 'message': 'You have no followers.',
-                'status': status.HTTP_400_BAD_REQUEST}
-            return Response(data=msg, status=status.HTTP_400_BAD_REQUEST)
+                'status': status.HTTP_204_NO_CONTENT}
+            return Response(data=msg, status=status.HTTP_204_NO_CONTENT)
         msg = {
             'followers': followers,
             'status': status.HTTP_200_OK}


### PR DESCRIPTION
### What does this PR do?

* Add the `following` key-value to the returned Profile object
* Change returned status for an empty list from 400 to 204