### PR TITLE
#163383194 Implement Users should be able to share articles

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -2,7 +2,8 @@ from rest_framework import serializers
 
 from . import models
 from ..profiles import serializers as ProfileSerializers
-from .utils.utils import get_article_read_time, get_articles_url
+from .utils.utils import (get_article_read_time, get_articles_url,
+                          get_sharing_links)
 
 
 class ArticleSerializer (serializers.ModelSerializer):
@@ -16,6 +17,7 @@ class ArticleSerializer (serializers.ModelSerializer):
     favorited = serializers.SerializerMethodField()
     average_ratings = serializers.IntegerField(required=False)
     read_time = serializers.SerializerMethodField()
+    share_links = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Article
@@ -36,6 +38,7 @@ class ArticleSerializer (serializers.ModelSerializer):
             "average_ratings",
             "tag_list",
             "read_time",
+            "share_links",
         )
         read_only_fields = (
             'author',
@@ -63,6 +66,9 @@ class ArticleSerializer (serializers.ModelSerializer):
 
     def get_read_time(self, obj):
         return get_article_read_time(obj.body)
+
+    def get_share_links(self, obj):
+        return get_sharing_links(obj, self.context['request'])
 
 
 class ArticleRatingSerializer(serializers.ModelSerializer):

--- a/authors/apps/articles/utils/utils.py
+++ b/authors/apps/articles/utils/utils.py
@@ -5,6 +5,7 @@ import readtime
 from django.utils.text import slugify
 from django.db.models import Avg
 from django.urls import reverse
+from urllib.parse import quote
 
 
 def unique_random_string(size=7):
@@ -55,3 +56,34 @@ def get_articles_url(obj, request):
                                                  'slug': obj.article.slug
                                              }))
     return url
+
+
+def get_sharing_links(obj, request):
+    """
+    This method creates links that will be used to post an article to
+    Facebook and Google Plus, or share an article as a tweet on Twitter
+    and also share the article through email to another email user
+
+    Parameters: Request of the body and the article object
+    Returns: share links for platforms of social media and email
+
+    """
+    share_links = dict()
+    url = request.build_absolute_uri(reverse('articles:article-details',
+                                             kwargs={'slug': obj.slug}))
+    title = quote(obj.title)
+    author = quote(obj.author.username)
+    space = quote(' ')
+    append_to_url = f'{title}{space}by{space}{author}{space}{url}'
+
+    share_links['google_plus'] = f"https://plus.google.com/share?url\
+={url}"
+    share_links['twitter'] = f"https://twitter.com/home?status={append_to_url}"
+    share_links['facebook'] = f"https://www.facebook.com/sharer/sharer.php?u\
+={url}"
+
+    message = quote('I am sharing this article, ')
+    body = (f"""{message}'{title}'%20{url}""")
+    share_links['email'] = f'mailto:?&subject={title}&body={body}'
+
+    return share_links


### PR DESCRIPTION
#### What does this PR do?

 Implement Users should be able to share articles across different channels

#### Description of Task to be completed?

- write tests to get sharable links for Facebook, Twitter, Google and email
- write method creates links that will be used to post an article to
    Facebook and Google Plus, or share an article as a tweet on Twitter
    and also share the article through email to another email user

#### How should this be manually tested?

* Fetch and checkout this branch `ft-bookmark-article-163383195`
* Create a virtual environment using `python3 -m virtualenv venv`  and activate it using `source venv\bin\activate`
* Install requirements using `pip install -r requirements.txt`
* Start the app `python manage.py runserver`
* On postman, Retrieve articles using the url `localhost:8000/api/v1/articles/`
* Under share_links for a single article, copy and paste either the twitter link, or facebook link, or google plus link in your browser to test them.
* To run tests, type this in the terminal: `python manage.py test`

#### What are the relevant pivotal tracker stories?

[#163383194](https://www.pivotaltracker.com/story/show/163383194)

#### Screenshots 
<img width="1171" alt="screenshot 2019-02-20 at 12 38 44" src="https://user-images.githubusercontent.com/31304859/53081745-8217fa80-350c-11e9-9c14-80d2d6f5619c.png">