### PR TITLE
bug fix: apply correct serializer to replies view

### DIFF
--- a/authors/apps/comments/views.py
+++ b/authors/apps/comments/views.py
@@ -194,7 +194,7 @@ class CommentReplyDetailApiView(GenericAPIView):
     deletion of a single reply.
     """
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
-    serializer_class = CommentSerializer
+    serializer_class = CommentReplySerializer
     renderer_classes = (JSONRenderer,)
 
     def get_required_objects(self, request, pk):


### PR DESCRIPTION
Detailed Description
- updated comment reply view to return data using the correct serializer

### Background
The comments reply view made use of an incorrect serializer to return the detailed response