### PR TITLE
fix: add the favorite field to search filters

### DIFF
--- a/authors/apps/articles/utils/custom_filters.py
+++ b/authors/apps/articles/utils/custom_filters.py
@@ -15,7 +15,9 @@ class ArticleFilter(FilterSet):
                                        lookup_expr='icontains')
     tag = rest_framework.CharFilter('tag_list',
                                     lookup_expr='icontains')
+    favorited_by = rest_framework.CharFilter('favorited_by__username',
+                                    lookup_expr='icontains')
 
     class Meta:
         model = Article
-        fields = ("title", "author", "tag", )
+        fields = ("title", "author", "tag", "favorited_by")


### PR DESCRIPTION
### Description of task
- add the favorite field to search filters

### Why was this necessary?
- The bookmark articles feature in the front-end requires an endpoint that allows it to fetch favorites articles