### PR TITLE
fix: remove auth for tags view

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -285,7 +285,6 @@ class ArticleRatingAPIView(generics.GenericAPIView):
 
 
 class ArticleTagsApiView(generics.GenericAPIView):
-    permission_classes = (permissions.IsAuthenticated,)
 
     def get(self, request):
         tags = get_all_available_tags()


### PR DESCRIPTION
### Description of task
- allow unauthenticated users to access tags

### Why was this necessary?
- The frontend tags view needs to access the tags for all users authenticated or not.